### PR TITLE
refactor: Reader 播放状态机建模 + UI 层提取

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ node_modules/
 _bmad/
 benchmark/reports/
 .worktrees
+.claude/skills/bmad*

--- a/docs/implementation-artifacts/deferred-work.md
+++ b/docs/implementation-artifacts/deferred-work.md
@@ -1,0 +1,11 @@
+# Deferred Work
+
+## From gh-15-reader-state-machine review
+
+- **Controls `_playing` 自行翻转可能与状态机脱同步**: Controls 的 click handler 在调用 onPlay/onPause 回调前就翻转 `_playing`。如果状态转换失败（如 loading 中暂停），UI 按钮状态与实际播放状态会脱同步。需要重构 Controls 使其仅通过 `setPlaying()` 被动响应状态机，不自行管理 `_playing`。
+- **`ensureBuffered` 无超时、port 断开时挂死**: 如果 TTS 请求已发出但 background port 断开且无 done/error 回复，`ensureBuffered` 的 Promise 永远不 resolve。`bgPort.onDisconnect` 应 reject 所有 pending requests。
+
+## From gh-15 issue split
+
+- **自动滚动仲裁** → GitHub Issue #21（v1.0.0）
+- **快捷键焦点冲突规避** → GitHub Issue #22（backlog）

--- a/docs/implementation-artifacts/spec-gh-15-extract-reader-ui.md
+++ b/docs/implementation-artifacts/spec-gh-15-extract-reader-ui.md
@@ -1,0 +1,78 @@
+---
+title: '提取 ReaderUI 层 + 拆分 playFromParagraph'
+type: 'refactor'
+created: '2026-03-26'
+status: 'done'
+baseline_commit: '284c6a9'
+context: ['docs/ref/extension-playback.md']
+---
+
+<frozen-after-approval reason="human-owned intent — do not modify unless human renegotiates">
+
+## Intent
+
+**Problem:** reader-core 直接操作 DOM（querySelectorAll、style.display、classList、createElement），违反 DI 原则，导致测试必须构造 JSDOM HTML。同时 `playFromParagraph` 在 ~80 行内混合了 DOM 操作、缓冲获取、音频解码播放、高亮同步、循环控制 5 个关注点，难以阅读和独立测试。
+
+**Approach:** 1) 提取 `createReaderUI` 模块封装全部 DOM 操作，reader-core 通过 `deps.ui` 接口调用；2) 将 `playFromParagraph` 拆分为 `playSingleSegment`（单段生命周期）+ 纯循环驱动。
+
+## Boundaries & Constraints
+
+**Always:**
+- `createReaderUI` 遵循项目 DI 模式：工厂函数，不引入 singleton
+- reader-core 重构后不直接引用任何 DOM API（document、querySelector、classList、style）
+- `deps.dom` 拆为 `deps.ui`（UI 接口）+ `deps.env`（window/location）
+- `renderSegments` 作为构造参数注入 `createReaderUI`，reader-core 只调 `ui.renderContent()`
+- 现有外部 API（init、cleanup）和行为不变
+
+**Ask First:**
+- 无
+
+**Never:**
+- 不改变状态机、WS 协议、player/scheduler/highlight 内部实现
+- 不改变 Controls 的接口
+
+## I/O & Edge-Case Matrix
+
+| Scenario | Input / State | Expected Output / Behavior | Error Handling |
+|----------|--------------|---------------------------|----------------|
+| showError | 任意错误消息 | 隐藏 loading、显示 error 文案 | N/A |
+| markCurrent | paraIndex=3 | 清除所有 .current-para、给 [data-para="3"] 加 .current-para | paraEl 不存在时静默跳过 |
+| markPlayed | paraIndex=3 | 移除 .current-para、加 .played | paraEl 不存在时静默跳过 |
+| renderContent | segments + url | 调用 renderSegments 写入 contentEl | N/A |
+| setTitle | "Test" | 创建 h1 并 prepend 到 contentEl | 空 title 时不创建 |
+| playSingleSegment 正常 | 有 audio buffer | markCurrent → 缓冲 → 解码 → 播放 → markPlayed → 返回 shouldContinue | N/A |
+| playSingleSegment 空 buffer | 无 audio chunks | markCurrent → 缓冲 → 跳过 → 返回 { skipped: true } | N/A |
+| playSingleSegment decode 失败 | decodeAudio 抛异常 | 状态机 error→cancel → 返回 shouldContinue | log.error |
+
+</frozen-after-approval>
+
+## Code Map
+
+- `extension/reader/components/reader-ui.js` -- 新建：DOM 操作封装（7 个方法）
+- `extension/reader/components/reader-ui.test.js` -- 新建：JSDOM 测试 DOM 操作正确性
+- `extension/reader/reader-core.js` -- 重构：deps.dom → deps.ui + deps.env，提取 playSingleSegment
+- `extension/reader/reader-core.test.js` -- 简化：mock UI 替代 JSDOM HTML 构造
+- `extension/reader/reader.js` -- 更新：组装 createReaderUI 并注入
+
+## Tasks & Acceptance
+
+**Execution:**
+- [x] `extension/reader/components/reader-ui.js` -- 创建 `createReaderUI({ contentEl, loadingEl, errorEl, document, renderSegments })`，7 个方法
+- [x] `extension/reader/components/reader-ui.test.js` -- 12 个 JSDOM 测试覆盖全部方法 + 边界情况
+- [x] `extension/reader/reader-core.js` -- deps.dom → deps.ui + deps.env；提取 playSingleSegment，playFromParagraph 变为 ~15 行循环驱动
+- [x] `extension/reader/reader-core.test.js` -- mock UI 替代 JSDOM HTML，移除 jsdom 依赖，43 个测试全部通过
+- [x] `extension/reader/reader.js` -- 导入 createReaderUI，组装真实 DOM 实现注入 deps.ui
+
+**Acceptance Criteria:**
+- Given reader-core, when 搜索 `querySelector|classList|style\.display|createElement`, then 零匹配
+- Given createReaderUI, when 调用 markCurrent(3), then [data-para="3"] 有 .current-para 且其他段落无此 class
+- Given createReaderUI, when 调用 markPlayed(3), then [data-para="3"] 无 .current-para 且有 .played
+- Given playSingleSegment, when buffer 有 audio, then 返回 { shouldContinue: boolean }
+- Given playSingleSegment, when buffer 为空, then 跳过并返回 { skipped: true }
+- Given 所有测试, when 运行 `node --test extension/**/*.test.js`, then 全部通过
+
+## Verification
+
+**Commands:**
+- `node --test extension/**/*.test.js` -- expected: 全部通过
+- `npx eslint extension` -- expected: 无错误

--- a/docs/implementation-artifacts/spec-gh-15-reader-state-machine.md
+++ b/docs/implementation-artifacts/spec-gh-15-reader-state-machine.md
@@ -1,0 +1,142 @@
+---
+title: 'Reader 播放状态机建模'
+type: 'refactor'
+created: '2026-03-24'
+status: 'done'
+baseline_commit: 'be12a44'
+context: ['docs/ref/extension-playback.md']
+---
+
+<frozen-after-approval reason="human-owned intent — do not modify unless human renegotiates">
+
+## Intent
+
+**Problem:** 播放状态分散在 reader-core（`currentParaIndex`, `bgConnected`）、Player（`_playing`）、Scheduler（`_connBusy`）、Controls（`_playing`）四处，缺乏统一状态模型。段落切换、取消/重启、跳转等操作各自管理状态，导致 #7 #8 #9 #10 无法可靠地构建在其上。
+
+**Approach:** 提取一个独立的 `playback-state.js` 状态机模块，定义 `idle → loading → playing ⇄ paused → idle` 状态枚举和转换规则，提供段落导航接口（`goTo(index)`）和事件订阅机制（`on(event, cb)`），reader-core 委托状态决策给状态机而非自行管理散落的标志位。
+
+## Boundaries & Constraints
+
+**Always:**
+- 遵循项目 DI 模式：`createPlaybackState(deps)` 工厂函数，不引入 singleton
+- 状态机是纯逻辑模块，不依赖 DOM/AudioContext/WebSocket
+- 所有状态转换通过显式方法调用（`transition(event)`），非法转换抛出或忽略并 log
+- reader-core 现有的外部 API（`init`, `cleanup`）和测试不被破坏
+
+**Ask First:**
+- 是否需要为状态机引入第三方库（如 xstate）还是手写轻量实现
+- 滚动仲裁和快捷键焦点是否纳入本次范围（issue 中提及但属于独立关注点）
+
+**Never:**
+- 不改变 WS 协议或后端行为
+- 不修改 player.js / scheduler.js / highlight.js 的内部实现
+- 不引入全局事件总线或 singleton 模式
+
+## I/O & Edge-Case Matrix
+
+| Scenario | Input / State | Expected Output / Behavior | Error Handling |
+|----------|--------------|---------------------------|----------------|
+| 正常播放流程 | idle + play() | idle → loading → playing → (段落结束) → loading → playing → ... → idle | N/A |
+| 用户暂停恢复 | playing + pause() | playing → paused; resume() → playing | N/A |
+| 播放中跳转 | playing + goTo(5) | playing → loading(target=5), 取消当前段落 → playing(segment=5) | N/A |
+| loading 中取消 | loading + cancel() | loading → idle, 清理 pending requests | N/A |
+| 非法转换 | idle + pause() | 忽略，log warning | 不抛异常 |
+| TTS 错误 | loading + error event | loading → error → (自动或手动) → idle | 通知订阅者 |
+| 连接断开重连 | playing + disconnect | playing → error; reconnect 成功 → idle（需用户重新点击 play） | 通知 UI 显示错误状态 |
+
+</frozen-after-approval>
+
+## Code Map
+
+- `extension/components/playback-state.js` -- 新建：状态机核心（状态枚举、转换规则、事件发射、段落导航）
+- `extension/components/playback-state.test.js` -- 新建：状态机单元测试
+- `extension/reader/reader-core.js` -- 重构：委托状态管理给 playback-state，移除散落的状态标志
+- `extension/reader/reader-core.test.js` -- 更新：适配新的状态管理方式
+- `extension/components/controls.js` -- 适配：通过状态机事件订阅更新 UI，移除本地 `_playing`
+
+## Tasks & Acceptance
+
+**Execution:**
+- [x] `extension/reader/components/playback-state.js` -- 创建状态机模块：状态枚举（`idle/loading/playing/paused/error`）、转换表、`on(event,cb)` 订阅、段落导航状态（`currentIndex/targetIndex`）、`transition()` 方法
+- [x] `extension/reader/components/playback-state.test.js` -- 编写状态机单元测试：39 个测试覆盖所有合法转换、非法转换忽略、事件通知、段落导航状态正确性
+- [x] `extension/reader/reader-core.js` -- 重构：注入 `createPlaybackState`，用 `state.transition('play')` 替代直接操作标志位，用 `state.on('stateChange', cb)` 驱动 controls 联动
+- [x] `extension/reader/reader-core.test.js` -- 更新现有测试：注入真实 `createPlaybackState`，42 个测试全部通过
+- [x] `extension/reader/components/controls.js` -- 保留现有 `_playing` 作为 UI 显示状态，由状态机通过 `stateChange` 事件驱动 `setPlaying()` 同步；reader-core 不再读取 `controls.isPlaying`
+
+**Acceptance Criteria:**
+- Given 状态机处于 idle, when 调用 `transition('play')`, then 状态变为 loading 并触发 `stateChange` 事件
+- Given 状态机处于 playing, when 调用 `goTo(n)`, then `targetIndex` 更新且状态转为 loading
+- Given 状态机处于 idle, when 调用 `transition('pause')`, then 状态不变并 log warning
+- Given reader-core 使用状态机, when 执行完整播放流程, then 行为与重构前一致
+- Given 所有测试, when 运行 `node --test extension/**/*.test.js`, then 全部通过
+
+## Design Notes
+
+**状态转换表（FSM）：**
+```
+idle     --play-->     loading
+loading  --buffered--> playing
+loading  --error-->    error
+loading  --cancel-->   idle
+playing  --pause-->    paused
+playing  --ended-->    loading   (自动下一段)
+playing  --finished--> idle      (最后一段结束)
+playing  --cancel-->   idle
+playing  --jump-->     loading   (goTo 触发)
+paused   --resume-->   playing
+paused   --cancel-->   idle
+paused   --jump-->     loading
+error    --retry-->    loading
+error    --cancel-->   idle
+```
+
+**事件接口：**
+```javascript
+const state = createPlaybackState({ paragraphCount: 10 });
+state.on('stateChange', ({ from, to, currentIndex, targetIndex }) => { ... });
+state.on('segmentChange', ({ from, to }) => { ... });
+state.transition('play');   // idle → loading
+state.goTo(5);              // sets targetIndex, triggers jump
+state.current;              // { state: 'loading', currentIndex: 0, targetIndex: 5 }
+```
+
+## Verification
+
+**Commands:**
+- `node --test extension/**/*.test.js` -- expected: 全部通过，含新增 playback-state 测试
+- `npx eslint extension` -- expected: 无错误
+
+## Suggested Review Order
+
+**状态机核心**
+
+- 转换表 + 事件系统：纯逻辑无依赖，所有播放状态的唯一来源
+  [`playback-state.js:1`](../../extension/reader/components/playback-state.js#L1)
+
+- `goTo` 段落跳转：设置 targetIndex 后委托给 transition
+  [`playback-state.js:66`](../../extension/reader/components/playback-state.js#L66)
+
+- `advanceIndex` 消费 targetIndex 或顺序递增
+  [`playback-state.js:96`](../../extension/reader/components/playback-state.js#L96)
+
+**编排集成**
+
+- `handlePlay`/`handlePause`：isLoading 守卫防并发，loading 时 pause 走 cancel 路径
+  [`reader-core.js:323`](../../extension/reader/reader-core.js#L323)
+
+- `playFromParagraph` 循环：以 state machine index 驱动，最后一段用 finished 而非 ended
+  [`reader-core.js:357`](../../extension/reader/reader-core.js#L357)
+
+- stateChange → controls.setPlaying 同步
+  [`reader-core.js:76`](../../extension/reader/reader-core.js#L76)
+
+- DI 入口注入 createPlaybackState
+  [`reader.js:7`](../../extension/reader/reader.js#L7)
+
+**测试**
+
+- 39 个状态机测试：转换、事件、goTo、完整播放循环
+  [`playback-state.test.js:1`](../../extension/reader/components/playback-state.test.js#L1)
+
+- 42 个 reader-core 测试：注入真实 createPlaybackState，既有行为不变
+  [`reader-core.test.js:6`](../../extension/reader/reader-core.test.js#L6)

--- a/extension/reader/components/playback-state.js
+++ b/extension/reader/components/playback-state.js
@@ -37,6 +37,18 @@ export function createPlaybackState({ paragraphCount, log } = {}) {
     error: { retry: "loading", cancel: "idle" },
   };
 
+  // Index side-effects per transition event — single source of truth
+  // for how transitions affect _currentIndex and _targetIndex.
+  const _effects = {
+    cancel: () => {
+      _targetIndex = null;
+    },
+    finished: () => {
+      _currentIndex = 0;
+      _targetIndex = null;
+    },
+  };
+
   // ── Core API ──────────────────────────────────────────────────
 
   function transition(event) {
@@ -48,21 +60,24 @@ export function createPlaybackState({ paragraphCount, log } = {}) {
     const from = _state;
     _state = allowed[event];
 
-    // Reset target on cancel
-    if (event === "cancel") {
-      _targetIndex = null;
-    }
+    const effect = _effects[event];
+    if (effect) effect();
 
-    // When finishing all paragraphs, reset index
-    if (event === "finished") {
-      _currentIndex = 0;
-      _targetIndex = null;
-    }
-
-    _emit("stateChange", { from, to: _state, event, currentIndex: _currentIndex, targetIndex: _targetIndex });
+    _emit("stateChange", {
+      from,
+      to: _state,
+      event,
+      currentIndex: _currentIndex,
+      targetIndex: _targetIndex,
+    });
     return true;
   }
 
+  /**
+   * Navigate to a specific paragraph.
+   * Sets targetIndex, then delegates to the appropriate transition.
+   * advanceIndex() will later consume targetIndex to set currentIndex.
+   */
   function goTo(index) {
     if (index < 0 || index >= _paragraphCount) {
       _log.warn(`goTo: index ${index} out of range [0, ${_paragraphCount})`);
@@ -71,17 +86,10 @@ export function createPlaybackState({ paragraphCount, log } = {}) {
 
     _targetIndex = index;
 
-    // From idle, goTo acts as play (idle → loading)
-    if (_state === "idle") {
-      return transition("play");
-    }
+    if (_state === "idle") return transition("play");
+    if (_state === "playing" || _state === "paused") return transition("jump");
 
-    // From playing/paused, goTo triggers jump (→ loading)
-    if (_state === "playing" || _state === "paused") {
-      return transition("jump");
-    }
-
-    // From loading, just update target (already loading)
+    // Already loading — just retarget without state change
     if (_state === "loading") {
       _emit("stateChange", {
         from: "loading",
@@ -97,6 +105,11 @@ export function createPlaybackState({ paragraphCount, log } = {}) {
     return false;
   }
 
+  /**
+   * Advance to the next segment.
+   * Consumes targetIndex (from goTo) if set, otherwise increments sequentially.
+   * Returns true if the new index is within bounds.
+   */
   function advanceIndex() {
     if (_targetIndex !== null) {
       _currentIndex = _targetIndex;

--- a/extension/reader/components/playback-state.js
+++ b/extension/reader/components/playback-state.js
@@ -1,0 +1,164 @@
+/**
+ * Playback state machine — pure logic, no DOM/Audio/WS dependencies.
+ *
+ * States: idle, loading, playing, paused, error
+ * Events: play, buffered, pause, resume, ended, finished, cancel, jump, error, retry
+ *
+ * @param {object} deps
+ * @param {number} deps.paragraphCount — total number of paragraphs
+ * @param {object} [deps.log] — logger with .warn() method
+ * @returns {PlaybackState}
+ */
+export function createPlaybackState({ paragraphCount, log } = {}) {
+  const _log = log || { warn() {} };
+
+  // ── State ─────────────────────────────────────────────────────
+  let _state = "idle";
+  let _currentIndex = 0;
+  let _targetIndex = null;
+  let _paragraphCount = paragraphCount || 0;
+
+  // ── Event listeners ───────────────────────────────────────────
+  const _listeners = new Map();
+
+  // ── Transition table ──────────────────────────────────────────
+  // { [currentState]: { [event]: nextState } }
+  const _transitions = {
+    idle: { play: "loading" },
+    loading: { buffered: "playing", error: "error", cancel: "idle" },
+    playing: {
+      pause: "paused",
+      ended: "loading",
+      finished: "idle",
+      cancel: "idle",
+      jump: "loading",
+    },
+    paused: { resume: "playing", cancel: "idle", jump: "loading" },
+    error: { retry: "loading", cancel: "idle" },
+  };
+
+  // ── Core API ──────────────────────────────────────────────────
+
+  function transition(event) {
+    const allowed = _transitions[_state];
+    if (!allowed || !(event in allowed)) {
+      _log.warn(`invalid transition: ${_state} --${event}-->`);
+      return false;
+    }
+    const from = _state;
+    _state = allowed[event];
+
+    // Reset target on cancel
+    if (event === "cancel") {
+      _targetIndex = null;
+    }
+
+    // When finishing all paragraphs, reset index
+    if (event === "finished") {
+      _currentIndex = 0;
+      _targetIndex = null;
+    }
+
+    _emit("stateChange", { from, to: _state, event, currentIndex: _currentIndex, targetIndex: _targetIndex });
+    return true;
+  }
+
+  function goTo(index) {
+    if (index < 0 || index >= _paragraphCount) {
+      _log.warn(`goTo: index ${index} out of range [0, ${_paragraphCount})`);
+      return false;
+    }
+
+    _targetIndex = index;
+
+    // From idle, goTo acts as play (idle → loading)
+    if (_state === "idle") {
+      return transition("play");
+    }
+
+    // From playing/paused, goTo triggers jump (→ loading)
+    if (_state === "playing" || _state === "paused") {
+      return transition("jump");
+    }
+
+    // From loading, just update target (already loading)
+    if (_state === "loading") {
+      _emit("stateChange", {
+        from: "loading",
+        to: "loading",
+        event: "retarget",
+        currentIndex: _currentIndex,
+        targetIndex: _targetIndex,
+      });
+      return true;
+    }
+
+    _log.warn(`goTo: ignored in state ${_state}`);
+    return false;
+  }
+
+  function advanceIndex() {
+    if (_targetIndex !== null) {
+      _currentIndex = _targetIndex;
+      _targetIndex = null;
+    } else {
+      _currentIndex++;
+    }
+
+    const changed = _currentIndex < _paragraphCount;
+    _emit("segmentChange", { index: _currentIndex });
+    return changed;
+  }
+
+  // ── Event emitter ─────────────────────────────────────────────
+
+  function on(event, cb) {
+    if (!_listeners.has(event)) _listeners.set(event, []);
+    _listeners.get(event).push(cb);
+    return () => {
+      const arr = _listeners.get(event);
+      if (arr) {
+        const idx = arr.indexOf(cb);
+        if (idx !== -1) arr.splice(idx, 1);
+      }
+    };
+  }
+
+  function _emit(event, data) {
+    const cbs = _listeners.get(event);
+    if (cbs) cbs.forEach((cb) => cb(data));
+  }
+
+  // ── Getters ───────────────────────────────────────────────────
+
+  return {
+    get state() {
+      return _state;
+    },
+    get currentIndex() {
+      return _currentIndex;
+    },
+    get targetIndex() {
+      return _targetIndex;
+    },
+    get paragraphCount() {
+      return _paragraphCount;
+    },
+    set paragraphCount(n) {
+      _paragraphCount = n;
+    },
+    get isPlaying() {
+      return _state === "playing";
+    },
+    get isLoading() {
+      return _state === "loading";
+    },
+    get current() {
+      return { state: _state, currentIndex: _currentIndex, targetIndex: _targetIndex };
+    },
+    transition,
+    goTo,
+    advanceIndex,
+    on,
+  };
+}

--- a/extension/reader/components/playback-state.test.js
+++ b/extension/reader/components/playback-state.test.js
@@ -1,0 +1,403 @@
+import { describe, it, mock } from "node:test";
+import assert from "node:assert/strict";
+import { createPlaybackState } from "./playback-state.js";
+
+// ── Helpers ──────────────────────────────────────────────────────
+
+function makeState(opts = {}) {
+  const log = { warn: mock.fn() };
+  return { ps: createPlaybackState({ paragraphCount: 5, log, ...opts }), log };
+}
+
+// ── Tests ────────────────────────────────────────────────────────
+
+describe("createPlaybackState", () => {
+  describe("initial state", () => {
+    it("starts in idle with index 0", () => {
+      const { ps } = makeState();
+      assert.equal(ps.state, "idle");
+      assert.equal(ps.currentIndex, 0);
+      assert.equal(ps.targetIndex, null);
+      assert.equal(ps.isPlaying, false);
+    });
+
+    it("exposes current snapshot", () => {
+      const { ps } = makeState();
+      assert.deepEqual(ps.current, { state: "idle", currentIndex: 0, targetIndex: null });
+    });
+  });
+
+  describe("valid transitions", () => {
+    it("idle --play--> loading", () => {
+      const { ps } = makeState();
+      assert.equal(ps.transition("play"), true);
+      assert.equal(ps.state, "loading");
+    });
+
+    it("loading --buffered--> playing", () => {
+      const { ps } = makeState();
+      ps.transition("play");
+      assert.equal(ps.transition("buffered"), true);
+      assert.equal(ps.state, "playing");
+    });
+
+    it("playing --pause--> paused", () => {
+      const { ps } = makeState();
+      ps.transition("play");
+      ps.transition("buffered");
+      assert.equal(ps.transition("pause"), true);
+      assert.equal(ps.state, "paused");
+    });
+
+    it("paused --resume--> playing", () => {
+      const { ps } = makeState();
+      ps.transition("play");
+      ps.transition("buffered");
+      ps.transition("pause");
+      assert.equal(ps.transition("resume"), true);
+      assert.equal(ps.state, "playing");
+    });
+
+    it("playing --ended--> loading (auto next segment)", () => {
+      const { ps } = makeState();
+      ps.transition("play");
+      ps.transition("buffered");
+      assert.equal(ps.transition("ended"), true);
+      assert.equal(ps.state, "loading");
+    });
+
+    it("playing --finished--> idle (last segment)", () => {
+      const { ps } = makeState();
+      ps.transition("play");
+      ps.transition("buffered");
+      assert.equal(ps.transition("finished"), true);
+      assert.equal(ps.state, "idle");
+      assert.equal(ps.currentIndex, 0); // reset on finish
+    });
+
+    it("playing --cancel--> idle", () => {
+      const { ps } = makeState();
+      ps.transition("play");
+      ps.transition("buffered");
+      assert.equal(ps.transition("cancel"), true);
+      assert.equal(ps.state, "idle");
+    });
+
+    it("playing --jump--> loading", () => {
+      const { ps } = makeState();
+      ps.transition("play");
+      ps.transition("buffered");
+      assert.equal(ps.transition("jump"), true);
+      assert.equal(ps.state, "loading");
+    });
+
+    it("loading --error--> error", () => {
+      const { ps } = makeState();
+      ps.transition("play");
+      assert.equal(ps.transition("error"), true);
+      assert.equal(ps.state, "error");
+    });
+
+    it("error --retry--> loading", () => {
+      const { ps } = makeState();
+      ps.transition("play");
+      ps.transition("error");
+      assert.equal(ps.transition("retry"), true);
+      assert.equal(ps.state, "loading");
+    });
+
+    it("error --cancel--> idle", () => {
+      const { ps } = makeState();
+      ps.transition("play");
+      ps.transition("error");
+      assert.equal(ps.transition("cancel"), true);
+      assert.equal(ps.state, "idle");
+    });
+
+    it("loading --cancel--> idle", () => {
+      const { ps } = makeState();
+      ps.transition("play");
+      assert.equal(ps.transition("cancel"), true);
+      assert.equal(ps.state, "idle");
+    });
+
+    it("paused --cancel--> idle", () => {
+      const { ps } = makeState();
+      ps.transition("play");
+      ps.transition("buffered");
+      ps.transition("pause");
+      assert.equal(ps.transition("cancel"), true);
+      assert.equal(ps.state, "idle");
+    });
+
+    it("paused --jump--> loading", () => {
+      const { ps } = makeState();
+      ps.transition("play");
+      ps.transition("buffered");
+      ps.transition("pause");
+      assert.equal(ps.transition("jump"), true);
+      assert.equal(ps.state, "loading");
+    });
+  });
+
+  describe("invalid transitions", () => {
+    it("idle --pause--> ignored, stays idle", () => {
+      const { ps, log } = makeState();
+      assert.equal(ps.transition("pause"), false);
+      assert.equal(ps.state, "idle");
+      assert.equal(log.warn.mock.callCount(), 1);
+    });
+
+    it("idle --resume--> ignored", () => {
+      const { ps } = makeState();
+      assert.equal(ps.transition("resume"), false);
+      assert.equal(ps.state, "idle");
+    });
+
+    it("loading --pause--> ignored", () => {
+      const { ps } = makeState();
+      ps.transition("play");
+      assert.equal(ps.transition("pause"), false);
+      assert.equal(ps.state, "loading");
+    });
+
+    it("playing --play--> ignored", () => {
+      const { ps } = makeState();
+      ps.transition("play");
+      ps.transition("buffered");
+      assert.equal(ps.transition("play"), false);
+      assert.equal(ps.state, "playing");
+    });
+
+    it("error --pause--> ignored", () => {
+      const { ps } = makeState();
+      ps.transition("play");
+      ps.transition("error");
+      assert.equal(ps.transition("pause"), false);
+      assert.equal(ps.state, "error");
+    });
+  });
+
+  describe("stateChange events", () => {
+    it("fires stateChange on valid transition", () => {
+      const { ps } = makeState();
+      const events = [];
+      ps.on("stateChange", (e) => events.push(e));
+
+      ps.transition("play");
+
+      assert.equal(events.length, 1);
+      assert.equal(events[0].from, "idle");
+      assert.equal(events[0].to, "loading");
+      assert.equal(events[0].event, "play");
+    });
+
+    it("does not fire stateChange on invalid transition", () => {
+      const { ps } = makeState();
+      const events = [];
+      ps.on("stateChange", (e) => events.push(e));
+
+      ps.transition("pause"); // invalid from idle
+
+      assert.equal(events.length, 0);
+    });
+
+    it("supports unsubscribe", () => {
+      const { ps } = makeState();
+      const events = [];
+      const unsub = ps.on("stateChange", (e) => events.push(e));
+
+      ps.transition("play");
+      unsub();
+      ps.transition("buffered");
+
+      assert.equal(events.length, 1); // only first event
+    });
+
+    it("supports multiple listeners", () => {
+      const { ps } = makeState();
+      const a = [], b = [];
+      ps.on("stateChange", (e) => a.push(e));
+      ps.on("stateChange", (e) => b.push(e));
+
+      ps.transition("play");
+
+      assert.equal(a.length, 1);
+      assert.equal(b.length, 1);
+    });
+  });
+
+  describe("goTo", () => {
+    it("from idle: transitions to loading with targetIndex", () => {
+      const { ps } = makeState();
+      const events = [];
+      ps.on("stateChange", (e) => events.push(e));
+
+      assert.equal(ps.goTo(3), true);
+      assert.equal(ps.state, "loading");
+      assert.equal(ps.targetIndex, 3);
+      assert.equal(events[0].to, "loading");
+    });
+
+    it("from playing: triggers jump to loading", () => {
+      const { ps } = makeState();
+      ps.transition("play");
+      ps.transition("buffered");
+
+      assert.equal(ps.goTo(2), true);
+      assert.equal(ps.state, "loading");
+      assert.equal(ps.targetIndex, 2);
+    });
+
+    it("from paused: triggers jump to loading", () => {
+      const { ps } = makeState();
+      ps.transition("play");
+      ps.transition("buffered");
+      ps.transition("pause");
+
+      assert.equal(ps.goTo(4), true);
+      assert.equal(ps.state, "loading");
+      assert.equal(ps.targetIndex, 4);
+    });
+
+    it("from loading: retargets without state change", () => {
+      const { ps } = makeState();
+      ps.transition("play");
+      const events = [];
+      ps.on("stateChange", (e) => events.push(e));
+
+      assert.equal(ps.goTo(3), true);
+      assert.equal(ps.state, "loading"); // stays loading
+      assert.equal(ps.targetIndex, 3);
+      assert.equal(events[0].event, "retarget");
+    });
+
+    it("rejects out-of-range index", () => {
+      const { ps, log } = makeState();
+      assert.equal(ps.goTo(-1), false);
+      assert.equal(ps.goTo(5), false); // paragraphCount is 5, max valid is 4
+      assert.equal(log.warn.mock.callCount(), 2);
+    });
+
+    it("rejects from error state", () => {
+      const { ps, log } = makeState();
+      ps.transition("play");
+      ps.transition("error");
+
+      assert.equal(ps.goTo(2), false);
+      assert.equal(log.warn.mock.callCount(), 1);
+    });
+  });
+
+  describe("advanceIndex", () => {
+    it("increments currentIndex sequentially", () => {
+      const { ps } = makeState();
+      ps.transition("play");
+
+      assert.equal(ps.advanceIndex(), true); // 0 → 1
+      assert.equal(ps.currentIndex, 1);
+      assert.equal(ps.advanceIndex(), true); // 1 → 2
+      assert.equal(ps.currentIndex, 2);
+    });
+
+    it("uses targetIndex when set", () => {
+      const { ps } = makeState();
+      ps.transition("play");
+      ps.transition("buffered");
+      ps.goTo(3); // sets targetIndex=3, state→loading
+
+      assert.equal(ps.advanceIndex(), true);
+      assert.equal(ps.currentIndex, 3);
+      assert.equal(ps.targetIndex, null); // consumed
+    });
+
+    it("returns false when past last paragraph", () => {
+      const { ps } = makeState({ paragraphCount: 2 });
+      ps.transition("play");
+
+      ps.advanceIndex(); // 0 → 1
+      assert.equal(ps.advanceIndex(), false); // 1 → 2 (out of range)
+    });
+
+    it("fires segmentChange event", () => {
+      const { ps } = makeState();
+      const events = [];
+      ps.on("segmentChange", (e) => events.push(e));
+
+      ps.advanceIndex();
+
+      assert.equal(events.length, 1);
+      assert.equal(events[0].index, 1);
+    });
+  });
+
+  describe("paragraphCount setter", () => {
+    it("allows updating paragraph count after creation", () => {
+      const { ps } = makeState({ paragraphCount: 0 });
+      assert.equal(ps.paragraphCount, 0);
+      ps.paragraphCount = 10;
+      assert.equal(ps.paragraphCount, 10);
+    });
+  });
+
+  describe("full playback cycle", () => {
+    it("plays through all segments sequentially", () => {
+      const { ps } = makeState({ paragraphCount: 3 });
+      const states = [];
+      ps.on("stateChange", (e) => states.push(`${e.from}->${e.to}`));
+
+      // Segment 0
+      ps.transition("play");     // idle → loading
+      ps.transition("buffered"); // loading → playing
+      ps.transition("ended");    // playing → loading (auto next)
+      ps.advanceIndex();         // 0 → 1
+
+      // Segment 1
+      ps.transition("buffered"); // loading → playing
+      ps.transition("ended");    // playing → loading
+      ps.advanceIndex();         // 1 → 2
+
+      // Segment 2 (last)
+      ps.transition("buffered"); // loading → playing
+      ps.transition("finished"); // playing → idle
+
+      assert.deepEqual(states, [
+        "idle->loading",
+        "loading->playing",
+        "playing->loading",
+        "loading->playing",
+        "playing->loading",
+        "loading->playing",
+        "playing->idle",
+      ]);
+      assert.equal(ps.state, "idle");
+    });
+
+    it("handles pause/resume mid-playback", () => {
+      const { ps } = makeState();
+      ps.transition("play");
+      ps.transition("buffered"); // playing
+
+      ps.transition("pause");    // paused
+      assert.equal(ps.state, "paused");
+
+      ps.transition("resume");   // playing
+      assert.equal(ps.state, "playing");
+    });
+
+    it("handles jump during playback", () => {
+      const { ps } = makeState();
+      ps.transition("play");
+      ps.transition("buffered"); // playing segment 0
+
+      ps.goTo(3);                // jump → loading, target=3
+      assert.equal(ps.state, "loading");
+
+      ps.advanceIndex();         // currentIndex = 3 (from target)
+      assert.equal(ps.currentIndex, 3);
+
+      ps.transition("buffered"); // loading → playing
+      assert.equal(ps.state, "playing");
+    });
+  });
+});

--- a/extension/reader/components/reader-ui.js
+++ b/extension/reader/components/reader-ui.js
@@ -1,0 +1,56 @@
+/**
+ * createReaderUI — encapsulates all DOM operations for the reader view.
+ *
+ * Reader-core calls these methods instead of touching DOM directly.
+ * Tests can mock this entire interface without JSDOM.
+ *
+ * @param {object} deps
+ * @param {HTMLElement} deps.contentEl — article container
+ * @param {HTMLElement} deps.loadingEl — loading indicator
+ * @param {HTMLElement} deps.errorEl — error display
+ * @param {Document} deps.document — for createElement / querySelector
+ * @param {Function} deps.renderSegments — (contentEl, segments, url) => void
+ */
+export function createReaderUI({ contentEl, loadingEl, errorEl, document, renderSegments }) {
+  function showLoading() {
+    loadingEl.style.display = "block";
+  }
+
+  function hideLoading() {
+    loadingEl.style.display = "none";
+  }
+
+  function showError(msg) {
+    loadingEl.style.display = "none";
+    errorEl.textContent = msg;
+    errorEl.style.display = "block";
+  }
+
+  function renderContent(segments, url) {
+    renderSegments(contentEl, segments, url);
+  }
+
+  function setTitle(title) {
+    if (!title) return;
+    const h1 = document.createElement("h1");
+    h1.textContent = title;
+    contentEl.prepend(h1);
+  }
+
+  function markCurrent(paraIndex) {
+    document.querySelectorAll("[data-para].current-para").forEach((p) => {
+      p.classList.remove("current-para");
+    });
+    const el = document.querySelector(`[data-para="${paraIndex}"]`);
+    if (el) el.classList.add("current-para");
+  }
+
+  function markPlayed(paraIndex) {
+    const el = document.querySelector(`[data-para="${paraIndex}"]`);
+    if (!el) return;
+    el.classList.remove("current-para");
+    el.classList.add("played");
+  }
+
+  return { showLoading, hideLoading, showError, renderContent, setTitle, markCurrent, markPlayed };
+}

--- a/extension/reader/components/reader-ui.test.js
+++ b/extension/reader/components/reader-ui.test.js
@@ -1,0 +1,130 @@
+import { describe, it, mock } from "node:test";
+import assert from "node:assert/strict";
+import { JSDOM } from "jsdom";
+import { createReaderUI } from "./reader-ui.js";
+
+function makeUI(html = "") {
+  const dom = new JSDOM(`<!DOCTYPE html><html><body>
+    <div id="loading" style="display:none"></div>
+    <div id="error" style="display:none"></div>
+    <article id="content">${html}</article>
+  </body></html>`);
+  const doc = dom.window.document;
+  const renderSegments = mock.fn();
+
+  const ui = createReaderUI({
+    contentEl: doc.getElementById("content"),
+    loadingEl: doc.getElementById("loading"),
+    errorEl: doc.getElementById("error"),
+    document: doc,
+    renderSegments,
+  });
+
+  return { ui, doc, renderSegments };
+}
+
+const PARA_HTML = `
+  <p data-para="0">Hello</p>
+  <p data-para="1">World</p>
+  <p data-para="2">Foo</p>
+`;
+
+describe("createReaderUI", () => {
+  describe("showLoading / hideLoading", () => {
+    it("shows loading indicator", () => {
+      const { ui, doc } = makeUI();
+      ui.showLoading();
+      assert.equal(doc.getElementById("loading").style.display, "block");
+    });
+
+    it("hides loading indicator", () => {
+      const { ui, doc } = makeUI();
+      ui.showLoading();
+      ui.hideLoading();
+      assert.equal(doc.getElementById("loading").style.display, "none");
+    });
+  });
+
+  describe("showError", () => {
+    it("hides loading and shows error message", () => {
+      const { ui, doc } = makeUI();
+      ui.showLoading();
+      ui.showError("Something broke");
+      assert.equal(doc.getElementById("loading").style.display, "none");
+      assert.equal(doc.getElementById("error").style.display, "block");
+      assert.equal(doc.getElementById("error").textContent, "Something broke");
+    });
+  });
+
+  describe("renderContent", () => {
+    it("delegates to renderSegments with contentEl", () => {
+      const { ui, doc, renderSegments } = makeUI();
+      const segments = [{ type: "text", text: "hi" }];
+      ui.renderContent(segments, "https://example.com");
+      assert.equal(renderSegments.mock.callCount(), 1);
+      const args = renderSegments.mock.calls[0].arguments;
+      assert.equal(args[0], doc.getElementById("content"));
+      assert.equal(args[1], segments);
+      assert.equal(args[2], "https://example.com");
+    });
+  });
+
+  describe("setTitle", () => {
+    it("creates h1 and prepends to contentEl", () => {
+      const { ui, doc } = makeUI();
+      ui.setTitle("My Title");
+      const h1 = doc.getElementById("content").querySelector("h1");
+      assert.ok(h1);
+      assert.equal(h1.textContent, "My Title");
+    });
+
+    it("does nothing for empty title", () => {
+      const { ui, doc } = makeUI();
+      ui.setTitle("");
+      assert.equal(doc.getElementById("content").querySelector("h1"), null);
+    });
+
+    it("does nothing for null title", () => {
+      const { ui, doc } = makeUI();
+      ui.setTitle(null);
+      assert.equal(doc.getElementById("content").querySelector("h1"), null);
+    });
+  });
+
+  describe("markCurrent", () => {
+    it("adds current-para class to target paragraph", () => {
+      const { ui, doc } = makeUI(PARA_HTML);
+      ui.markCurrent(1);
+      assert.ok(doc.querySelector('[data-para="1"]').classList.contains("current-para"));
+    });
+
+    it("removes current-para from previously marked paragraph", () => {
+      const { ui, doc } = makeUI(PARA_HTML);
+      ui.markCurrent(0);
+      ui.markCurrent(1);
+      assert.ok(!doc.querySelector('[data-para="0"]').classList.contains("current-para"));
+      assert.ok(doc.querySelector('[data-para="1"]').classList.contains("current-para"));
+    });
+
+    it("does not throw for non-existent paragraph", () => {
+      const { ui } = makeUI(PARA_HTML);
+      ui.markCurrent(99); // should not throw
+    });
+  });
+
+  describe("markPlayed", () => {
+    it("removes current-para and adds played class", () => {
+      const { ui, doc } = makeUI(PARA_HTML);
+      ui.markCurrent(1);
+      ui.markPlayed(1);
+      const el = doc.querySelector('[data-para="1"]');
+      assert.ok(!el.classList.contains("current-para"));
+      assert.ok(el.classList.contains("played"));
+    });
+
+    it("does not throw for non-existent paragraph", () => {
+      const { ui } = makeUI(PARA_HTML);
+      ui.markPlayed(99); // should not throw
+    });
+  });
+});

--- a/extension/reader/reader-core.js
+++ b/extension/reader/reader-core.js
@@ -7,7 +7,7 @@
  * @param {object} deps
  * @param {object} deps.dom           — DOM elements and globals
  * @param {object} deps.browser       — browser.runtime / browser.storage
- * @param {object} deps.components    — factory functions for Player, Highlight, Controls, Scheduler
+ * @param {object} deps.components    — factory functions for Player, Highlight, Controls, Scheduler, PlaybackState
  * @param {object} deps.functions     — pure functions (pipeline, voice, config, etc.)
  * @returns {{ init(): Promise<void>, cleanup(): void, _ensureBuffered(i): Promise<void>, _dispatchFetch(f): void, _playFromParagraph(i): Promise<void> }}
  */
@@ -17,12 +17,12 @@ export function createReader(deps) {
   // ── Internal state ──────────────────────────────────────────────
   let config = null;
   let paragraphs = [];
-  let currentParaIndex = 0;
   let voice = "en-US-AriaNeural";
   let currentLang = "en";
   let userChangedVoice = false;
   let scheduler = null;
   let log = null;
+  let playbackState = null;
 
   let bgPort = null;
   let bgConnected = false;
@@ -48,6 +48,12 @@ export function createReader(deps) {
     const logger = new functions.Logger(debug);
     log = logger.scope("reader");
 
+    // Create playback state machine (paragraphCount set after pipeline)
+    playbackState = components.createPlaybackState({
+      paragraphCount: 0,
+      log,
+    });
+
     // Controls created after logger so we can inject a scoped logger
     controls = components.createControls(
       {
@@ -65,6 +71,12 @@ export function createReader(deps) {
       },
       { log: logger.scope("controls") }
     );
+
+    // Wire state machine → controls sync
+    playbackState.on("stateChange", ({ to }) => {
+      const playing = to === "playing";
+      controls.setPlaying(playing);
+    });
 
     dom.window.parent.postMessage({ type: "lactor-ready" }, "*");
 
@@ -94,6 +106,9 @@ export function createReader(deps) {
         showError("Could not extract readable text from this page.");
         return;
       }
+
+      // Update state machine with actual paragraph count
+      playbackState.paragraphCount = paragraphs.length;
 
       functions.renderSegments(dom.contentEl, segments, resp.data.url);
 
@@ -306,7 +321,7 @@ export function createReader(deps) {
   // ── Playback ────────────────────────────────────────────────────
 
   async function handlePlay() {
-    if (player.playing) return;
+    if (playbackState.isPlaying || playbackState.isLoading) return;
 
     if (!bgConnected && bgPort) {
       log.log("play: reconnecting WS before resume");
@@ -314,15 +329,30 @@ export function createReader(deps) {
     }
 
     if (player.hasBuffer) {
-      await player.resume();
+      playbackState.transition("play");
+      playbackState.transition("buffered");
+      try {
+        await player.resume();
+      } catch (err) {
+        log.error("resume failed:", err);
+        playbackState.transition("pause");
+        return;
+      }
       highlight.start(() => player.getCurrentTimeMs());
       return;
     }
 
-    await playFromParagraph(currentParaIndex);
+    playbackState.transition("play");
+    await playFromParagraph(playbackState.currentIndex);
   }
 
   async function handlePause() {
+    // Use "cancel" from loading (pause is only valid from playing)
+    if (playbackState.state === "loading") {
+      playbackState.transition("cancel");
+    } else {
+      playbackState.transition("pause");
+    }
     await player.pause();
     highlight.stop();
   }
@@ -331,7 +361,6 @@ export function createReader(deps) {
     let paraIndex = startIndex;
 
     while (paraIndex < paragraphs.length) {
-      currentParaIndex = paraIndex;
       log.log(`playFromParagraph(${paraIndex}/${paragraphs.length - 1})`);
 
       dom.document
@@ -340,17 +369,27 @@ export function createReader(deps) {
       const paraEl = dom.document.querySelector(`[data-para="${paraIndex}"]`);
       if (paraEl) paraEl.classList.add("current-para");
 
+      // Ensure we're in loading state for this segment
+      if (playbackState.state !== "loading") {
+        if (!playbackState.transition("play")) return;
+      }
+
       try {
         await ensureBuffered(paraIndex);
       } catch {
         return; // cleanup was called, stop playback silently
       }
+
+      // Bail out if cancelled/paused during loading
+      if (playbackState.state !== "loading") return;
+
       tryPrefetch();
 
       const buf = buffers.get(paraIndex);
       if (!buf || buf.audioChunks.length === 0) {
         log.warn(`para ${paraIndex} has no audio chunks, skipping`);
-        paraIndex++;
+        playbackState.advanceIndex();
+        paraIndex = playbackState.currentIndex;
         continue;
       }
 
@@ -359,13 +398,16 @@ export function createReader(deps) {
         const audioBuffer = await player.decodeAudio(buf.audioChunks);
         log.log(`para ${paraIndex} decoded, duration=${audioBuffer.duration.toFixed(2)}s, playing`);
 
+        // Transition to playing
+        playbackState.transition("buffered");
+
         highlight.loadParagraph(paraIndex);
         highlight.addWordEvents(buf.wordEvents);
 
         // Wrap callback-based play in a Promise to await within the loop
         const shouldContinue = await new Promise((resolve) => {
           player.play(audioBuffer, () => {
-            log.log(`para ${paraIndex} playback ended, isPlaying=${controls.isPlaying}`);
+            log.log(`para ${paraIndex} playback ended, isPlaying=${playbackState.isPlaying}`);
             highlight.stop();
             if (paraEl) {
               paraEl.classList.remove("current-para");
@@ -374,27 +416,44 @@ export function createReader(deps) {
             buffers.delete(paraIndex);
             scheduler.onPlaybackComplete();
             tryPrefetch();
-            resolve(controls.isPlaying);
+            resolve(playbackState.isPlaying);
           });
 
           highlight.start(() => player.getCurrentTimeMs());
         });
 
         if (!shouldContinue) return;
+
+        // Last paragraph: use "finished" to return to idle
+        const hasMore = playbackState.advanceIndex();
+        if (!hasMore) {
+          playbackState.transition("finished");
+          return;
+        }
+
+        // More paragraphs: transition to loading for next segment
+        playbackState.transition("ended");
+        paraIndex = playbackState.currentIndex;
       } catch (err) {
         log.error(`decode failed para ${paraIndex}:`, err);
+        playbackState.transition("error");
+        playbackState.transition("cancel");
+        playbackState.advanceIndex();
+        paraIndex = playbackState.currentIndex;
       }
-
-      paraIndex++;
     }
 
     log.log("all paragraphs finished");
-    controls.setPlaying(false);
+    // Reach idle from whatever state we're in
+    if (!playbackState.transition("finished") && !playbackState.transition("cancel")) {
+      controls.setPlaying(false);
+    }
   }
 
   // ── Cleanup ─────────────────────────────────────────────────────
 
   function cleanup() {
+    if (playbackState) playbackState.transition("cancel");
     for (const id of activeRetryTimers) clearTimeout(id);
     activeRetryTimers.clear();
     reconnectPending = false;

--- a/extension/reader/reader-core.js
+++ b/extension/reader/reader-core.js
@@ -1,18 +1,19 @@
 /**
  * createReader(deps) — testable orchestrator factory for the Lactor reader view.
  *
- * All DOM, browser API, and component dependencies are injected via `deps`.
+ * All browser API, UI, and component dependencies are injected via `deps`.
  * The thin entry point (reader.js) wires real dependencies and calls init().
  *
  * @param {object} deps
- * @param {object} deps.dom           — DOM elements and globals
+ * @param {object} deps.ui            — ReaderUI interface (showLoading, showError, markCurrent, etc.)
+ * @param {object} deps.env           — window (postMessage) and location (search params)
  * @param {object} deps.browser       — browser.runtime / browser.storage
  * @param {object} deps.components    — factory functions for Player, Highlight, Controls, Scheduler, PlaybackState
  * @param {object} deps.functions     — pure functions (pipeline, voice, config, etc.)
  * @returns {{ init(): Promise<void>, cleanup(): void, _ensureBuffered(i): Promise<void>, _dispatchFetch(f): void, _playFromParagraph(i): Promise<void> }}
  */
 export function createReader(deps) {
-  const { dom, browser, components, functions } = deps;
+  const { ui, env, browser, components, functions } = deps;
 
   // ── Internal state ──────────────────────────────────────────────
   let config = null;
@@ -66,7 +67,7 @@ export function createReader(deps) {
         },
         onClose: () => {
           cleanup();
-          dom.window.parent.postMessage({ type: "lactor-close" }, "*");
+          env.window.parent.postMessage({ type: "lactor-close" }, "*");
         },
       },
       { log: logger.scope("controls") }
@@ -78,22 +79,22 @@ export function createReader(deps) {
       controls.setPlaying(playing);
     });
 
-    dom.window.parent.postMessage({ type: "lactor-ready" }, "*");
+    env.window.parent.postMessage({ type: "lactor-ready" }, "*");
 
     config = await functions.loadConfig(browser.storage.local);
 
-    const params = new URLSearchParams(dom.location.search);
+    const params = new URLSearchParams(env.location.search);
     const tabId = parseInt(params.get("tabId"), 10);
     if (isNaN(tabId)) {
-      showError("Invalid tab ID");
+      ui.showError("Invalid tab ID");
       return;
     }
 
-    dom.loadingEl.style.display = "block";
+    ui.showLoading();
     try {
       const resp = await browser.runtime.sendMessage({ type: "getContent", tabId });
       if (!resp || !resp.data) {
-        showError("No content available. Try clicking the Lactor icon again.");
+        ui.showError("No content available. Try clicking the Lactor icon again.");
         return;
       }
 
@@ -103,22 +104,16 @@ export function createReader(deps) {
       paragraphs = segments.map((s) => s.text);
 
       if (paragraphs.length === 0) {
-        showError("Could not extract readable text from this page.");
+        ui.showError("Could not extract readable text from this page.");
         return;
       }
 
       // Update state machine with actual paragraph count
       playbackState.paragraphCount = paragraphs.length;
 
-      functions.renderSegments(dom.contentEl, segments, resp.data.url);
-
-      if (resp.data.title) {
-        const h1 = dom.document.createElement("h1");
-        h1.textContent = resp.data.title;
-        dom.contentEl.prepend(h1);
-      }
-
-      dom.loadingEl.style.display = "none";
+      ui.renderContent(segments, resp.data.url);
+      ui.setTitle(resp.data.title);
+      ui.hideLoading();
 
       // Voice resolution: cache-first, then fresh
       currentLang = ctx.lang || "en";
@@ -153,16 +148,8 @@ export function createReader(deps) {
       scheduler = components.createScheduler(paragraphs, 3);
       connectToBg();
     } catch (err) {
-      showError(`Failed to load content: ${err.message}`);
+      ui.showError(`Failed to load content: ${err.message}`);
     }
-  }
-
-  // ── UI helpers ──────────────────────────────────────────────────
-
-  function showError(msg) {
-    dom.loadingEl.style.display = "none";
-    dom.errorEl.textContent = msg;
-    dom.errorEl.style.display = "block";
   }
 
   // ── Port communication ──────────────────────────────────────────
@@ -306,16 +293,12 @@ export function createReader(deps) {
 
   function tryPrefetch() {
     if (!scheduler) return;
-    const remainingMs = getRemainingPlaybackMs();
+    const remainingMs = player.getRemainingMs();
     while (scheduler.shouldPrefetch(remainingMs)) {
       const next = scheduler.getNextFetch();
       if (!next) break;
       dispatchFetch(next);
     }
-  }
-
-  function getRemainingPlaybackMs() {
-    return player.getRemainingMs();
   }
 
   // ── Playback ────────────────────────────────────────────────────
@@ -357,94 +340,95 @@ export function createReader(deps) {
     highlight.stop();
   }
 
+  /**
+   * Play a single segment: buffer → decode → play → wait for end.
+   * Returns { shouldContinue, skipped } to let the caller drive the loop.
+   */
+  async function playSingleSegment(paraIndex) {
+    log.log(`playSingleSegment(${paraIndex}/${paragraphs.length - 1})`);
+    ui.markCurrent(paraIndex);
+
+    // Ensure we're in loading state
+    if (playbackState.state !== "loading") {
+      if (!playbackState.transition("play")) return { shouldContinue: false };
+    }
+
+    try {
+      await ensureBuffered(paraIndex);
+    } catch {
+      return { shouldContinue: false }; // cleanup was called
+    }
+
+    // Bail out if cancelled/paused during loading
+    if (playbackState.state !== "loading") return { shouldContinue: false };
+
+    tryPrefetch();
+
+    const buf = buffers.get(paraIndex);
+    if (!buf || buf.audioChunks.length === 0) {
+      log.warn(`para ${paraIndex} has no audio chunks, skipping`);
+      return { shouldContinue: true, skipped: true };
+    }
+
+    try {
+      log.log(`para ${paraIndex} decoding ${buf.audioChunks.length} chunks...`);
+      const audioBuffer = await player.decodeAudio(buf.audioChunks);
+      log.log(`para ${paraIndex} decoded, duration=${audioBuffer.duration.toFixed(2)}s, playing`);
+
+      playbackState.transition("buffered");
+
+      highlight.loadParagraph(paraIndex);
+      highlight.addWordEvents(buf.wordEvents);
+
+      const shouldContinue = await new Promise((resolve) => {
+        player.play(audioBuffer, () => {
+          log.log(`para ${paraIndex} playback ended, isPlaying=${playbackState.isPlaying}`);
+          highlight.stop();
+          ui.markPlayed(paraIndex);
+          buffers.delete(paraIndex);
+          scheduler.onPlaybackComplete();
+          tryPrefetch();
+          resolve(playbackState.isPlaying);
+        });
+
+        highlight.start(() => player.getCurrentTimeMs());
+      });
+
+      return { shouldContinue };
+    } catch (err) {
+      log.error(`decode failed para ${paraIndex}:`, err);
+      playbackState.transition("error");
+      playbackState.transition("cancel");
+      return { shouldContinue: false };
+    }
+  }
+
   async function playFromParagraph(startIndex) {
     let paraIndex = startIndex;
 
     while (paraIndex < paragraphs.length) {
-      log.log(`playFromParagraph(${paraIndex}/${paragraphs.length - 1})`);
+      const result = await playSingleSegment(paraIndex);
 
-      dom.document
-        .querySelectorAll("[data-para]")
-        .forEach((p) => p.classList.remove("current-para"));
-      const paraEl = dom.document.querySelector(`[data-para="${paraIndex}"]`);
-      if (paraEl) paraEl.classList.add("current-para");
+      if (!result.shouldContinue) return;
 
-      // Ensure we're in loading state for this segment
-      if (playbackState.state !== "loading") {
-        if (!playbackState.transition("play")) return;
-      }
-
-      try {
-        await ensureBuffered(paraIndex);
-      } catch {
-        return; // cleanup was called, stop playback silently
-      }
-
-      // Bail out if cancelled/paused during loading
-      if (playbackState.state !== "loading") return;
-
-      tryPrefetch();
-
-      const buf = buffers.get(paraIndex);
-      if (!buf || buf.audioChunks.length === 0) {
-        log.warn(`para ${paraIndex} has no audio chunks, skipping`);
+      if (result.skipped) {
         playbackState.advanceIndex();
         paraIndex = playbackState.currentIndex;
         continue;
       }
 
-      try {
-        log.log(`para ${paraIndex} decoding ${buf.audioChunks.length} chunks...`);
-        const audioBuffer = await player.decodeAudio(buf.audioChunks);
-        log.log(`para ${paraIndex} decoded, duration=${audioBuffer.duration.toFixed(2)}s, playing`);
-
-        // Transition to playing
-        playbackState.transition("buffered");
-
-        highlight.loadParagraph(paraIndex);
-        highlight.addWordEvents(buf.wordEvents);
-
-        // Wrap callback-based play in a Promise to await within the loop
-        const shouldContinue = await new Promise((resolve) => {
-          player.play(audioBuffer, () => {
-            log.log(`para ${paraIndex} playback ended, isPlaying=${playbackState.isPlaying}`);
-            highlight.stop();
-            if (paraEl) {
-              paraEl.classList.remove("current-para");
-              paraEl.classList.add("played");
-            }
-            buffers.delete(paraIndex);
-            scheduler.onPlaybackComplete();
-            tryPrefetch();
-            resolve(playbackState.isPlaying);
-          });
-
-          highlight.start(() => player.getCurrentTimeMs());
-        });
-
-        if (!shouldContinue) return;
-
-        // Last paragraph: use "finished" to return to idle
-        const hasMore = playbackState.advanceIndex();
-        if (!hasMore) {
-          playbackState.transition("finished");
-          return;
-        }
-
-        // More paragraphs: transition to loading for next segment
-        playbackState.transition("ended");
-        paraIndex = playbackState.currentIndex;
-      } catch (err) {
-        log.error(`decode failed para ${paraIndex}:`, err);
-        playbackState.transition("error");
-        playbackState.transition("cancel");
-        playbackState.advanceIndex();
-        paraIndex = playbackState.currentIndex;
+      // Segment played successfully — advance
+      const hasMore = playbackState.advanceIndex();
+      if (!hasMore) {
+        playbackState.transition("finished");
+        return;
       }
+
+      playbackState.transition("ended");
+      paraIndex = playbackState.currentIndex;
     }
 
     log.log("all paragraphs finished");
-    // Reach idle from whatever state we're in
     if (!playbackState.transition("finished") && !playbackState.transition("cancel")) {
       controls.setPlaying(false);
     }

--- a/extension/reader/reader-core.test.js
+++ b/extension/reader/reader-core.test.js
@@ -3,6 +3,7 @@ import assert from "node:assert/strict";
 import { JSDOM } from "jsdom";
 
 const { createReader } = await import("./reader-core.js");
+const { createPlaybackState } = await import("./components/playback-state.js");
 
 // ── Mock helpers ────────────────────────────────────────────────
 
@@ -120,6 +121,7 @@ function makeDeps(overrides = {}) {
         return mockControls;
       },
       createScheduler: () => mockScheduler,
+      createPlaybackState: (opts) => createPlaybackState(opts),
     },
     functions: {
       loadConfig: mock.fn(async () => ({

--- a/extension/reader/reader-core.test.js
+++ b/extension/reader/reader-core.test.js
@@ -1,6 +1,5 @@
 import { describe, it, mock } from "node:test";
 import assert from "node:assert/strict";
-import { JSDOM } from "jsdom";
 
 const { createReader } = await import("./reader-core.js");
 const { createPlaybackState } = await import("./components/playback-state.js");
@@ -71,26 +70,29 @@ function makeMockScheduler() {
   };
 }
 
-function makeDeps(overrides = {}) {
-  const dom = new JSDOM(`<!DOCTYPE html><html><body>
-    <div id="loading" style="display:none"></div>
-    <div id="error" style="display:none"></div>
-    <article id="content"></article>
-  </body></html>`);
-  const doc = dom.window.document;
+function makeMockUI() {
+  return {
+    showLoading: mock.fn(),
+    hideLoading: mock.fn(),
+    showError: mock.fn(),
+    renderContent: mock.fn(),
+    setTitle: mock.fn(),
+    markCurrent: mock.fn(),
+    markPlayed: mock.fn(),
+  };
+}
 
+function makeDeps(overrides = {}) {
   const mockPort = makeMockPort();
   const mockPlayer = makeMockPlayer();
   const mockHighlight = makeMockHighlight();
   let mockControls;
   const mockScheduler = makeMockScheduler();
+  const mockUI = makeMockUI();
 
   const deps = {
-    dom: {
-      contentEl: doc.getElementById("content"),
-      loadingEl: doc.getElementById("loading"),
-      errorEl: doc.getElementById("error"),
-      document: doc,
+    ui: mockUI,
+    env: {
       window: {
         parent: { postMessage: mock.fn() },
         addEventListener: mock.fn(),
@@ -161,11 +163,13 @@ function makeDeps(overrides = {}) {
       mockPlayer,
       mockHighlight,
       mockScheduler,
+      mockUI,
     },
   };
 
   // Apply overrides (shallow merge per category)
-  if (overrides.dom) Object.assign(deps.dom, overrides.dom);
+  if (overrides.ui) Object.assign(deps.ui, overrides.ui);
+  if (overrides.env) Object.assign(deps.env, overrides.env);
   if (overrides.browser) {
     if (overrides.browser.runtime) Object.assign(deps.browser.runtime, overrides.browser.runtime);
     if (overrides.browser.storage) Object.assign(deps.browser.storage, overrides.browser.storage);
@@ -183,7 +187,7 @@ describe("createReader", () => {
       const deps = makeDeps();
       const reader = createReader(deps);
       await reader.init();
-      const calls = deps.dom.window.parent.postMessage.mock.calls;
+      const calls = deps.env.window.parent.postMessage.mock.calls;
       assert.ok(calls.some((c) => c.arguments[0].type === "lactor-ready"));
     });
 
@@ -202,30 +206,29 @@ describe("createReader", () => {
       assert.deepEqual(call.arguments[0], { type: "getContent", tabId: 42 });
     });
 
-    it("runs pipeline and renders segments", async () => {
+    it("calls ui.renderContent with segments and url", async () => {
       const deps = makeDeps();
       const reader = createReader(deps);
       await reader.init();
-      assert.equal(deps.functions.renderSegments.mock.callCount(), 1);
-      const args = deps.functions.renderSegments.mock.calls[0].arguments;
-      assert.equal(args[0], deps.dom.contentEl); // contentEl
-      assert.equal(args[1].length, 2); // 2 segments
+      assert.equal(deps._mocks.mockUI.renderContent.mock.callCount(), 1);
+      const args = deps._mocks.mockUI.renderContent.mock.calls[0].arguments;
+      assert.equal(args[0].length, 2); // 2 segments
+      assert.equal(args[1], "https://example.com");
     });
 
-    it("prepends title h1 when title exists", async () => {
+    it("calls ui.setTitle with page title", async () => {
       const deps = makeDeps();
       const reader = createReader(deps);
       await reader.init();
-      const h1 = deps.dom.contentEl.querySelector("h1");
-      assert.ok(h1);
-      assert.equal(h1.textContent, "Test Title");
+      assert.equal(deps._mocks.mockUI.setTitle.mock.callCount(), 1);
+      assert.equal(deps._mocks.mockUI.setTitle.mock.calls[0].arguments[0], "Test Title");
     });
 
     it("hides loading indicator after content loads", async () => {
       const deps = makeDeps();
       const reader = createReader(deps);
       await reader.init();
-      assert.equal(deps.dom.loadingEl.style.display, "none");
+      assert.equal(deps._mocks.mockUI.hideLoading.mock.callCount(), 1);
     });
 
     it("connects to background after successful init", async () => {
@@ -275,11 +278,11 @@ describe("createReader", () => {
 
   describe("init — error paths", () => {
     it("shows error for invalid tabId", async () => {
-      const deps = makeDeps({ dom: { location: { search: "?tabId=abc" } } });
+      const deps = makeDeps({ env: { location: { search: "?tabId=abc" } } });
       const reader = createReader(deps);
       await reader.init();
-      assert.equal(deps.dom.errorEl.style.display, "block");
-      assert.match(deps.dom.errorEl.textContent, /Invalid tab ID/);
+      assert.equal(deps._mocks.mockUI.showError.mock.callCount(), 1);
+      assert.match(deps._mocks.mockUI.showError.mock.calls[0].arguments[0], /Invalid tab ID/);
     });
 
     it("shows error when sendMessage returns null", async () => {
@@ -287,7 +290,7 @@ describe("createReader", () => {
       deps.browser.runtime.sendMessage = mock.fn(async () => null);
       const reader = createReader(deps);
       await reader.init();
-      assert.match(deps.dom.errorEl.textContent, /No content available/);
+      assert.match(deps._mocks.mockUI.showError.mock.calls[0].arguments[0], /No content available/);
     });
 
     it("shows error when sendMessage returns no data", async () => {
@@ -295,7 +298,7 @@ describe("createReader", () => {
       deps.browser.runtime.sendMessage = mock.fn(async () => ({ data: null }));
       const reader = createReader(deps);
       await reader.init();
-      assert.match(deps.dom.errorEl.textContent, /No content available/);
+      assert.match(deps._mocks.mockUI.showError.mock.calls[0].arguments[0], /No content available/);
     });
 
     it("shows error when pipeline produces empty segments", async () => {
@@ -306,7 +309,7 @@ describe("createReader", () => {
       });
       const reader = createReader(deps);
       await reader.init();
-      assert.match(deps.dom.errorEl.textContent, /Could not extract/);
+      assert.match(deps._mocks.mockUI.showError.mock.calls[0].arguments[0], /Could not extract/);
     });
 
     it("shows error when content fetch throws", async () => {
@@ -316,11 +319,14 @@ describe("createReader", () => {
       });
       const reader = createReader(deps);
       await reader.init();
-      assert.match(deps.dom.errorEl.textContent, /Failed to load content/);
+      assert.match(
+        deps._mocks.mockUI.showError.mock.calls[0].arguments[0],
+        /Failed to load content/
+      );
     });
 
     it("does not connect to background on error", async () => {
-      const deps = makeDeps({ dom: { location: { search: "?tabId=abc" } } });
+      const deps = makeDeps({ env: { location: { search: "?tabId=abc" } } });
       const reader = createReader(deps);
       await reader.init();
       assert.equal(deps.browser.runtime.connect.mock.callCount(), 0);
@@ -340,7 +346,6 @@ describe("createReader", () => {
       deps.functions.loadCachedVoices = mock.fn(async () => [
         { name: "en-US-AriaNeural", locale: "en-US" },
       ]);
-      // Make fetchVoices slow enough that we can trigger onVoiceChange before it resolves
       let fetchVoicesResolve;
       const freshVoices = [{ name: "en-US-GuyNeural", locale: "en-US" }];
       deps.functions.fetchVoices = mock.fn(
@@ -351,20 +356,15 @@ describe("createReader", () => {
       );
 
       const initPromise = createReader(deps).init();
-      // Wait for cache-based voice to be set, then simulate user changing voice
       await new Promise((r) => setTimeout(r, 10));
       if (fetchVoicesResolve) {
-        // Simulate user changed voice before fresh voices arrive
         deps._mocks.mockControls._cbs.onVoiceChange("ja-JP-NanamiNeural");
         fetchVoicesResolve();
       }
       await initPromise;
 
-      // resolveVoice should NOT have been called again for fresh voices
-      // because userChangedVoice was set to true
       const setVoiceCalls = deps._mocks.mockControls.setVoice.mock.calls;
       const lastSetVoice = setVoiceCalls[setVoiceCalls.length - 1]?.arguments[0];
-      // Should NOT have overwritten the user's manual choice with fresh voice resolution
       assert.notEqual(lastSetVoice, "en-US-GuyNeural");
     });
 
@@ -381,8 +381,6 @@ describe("createReader", () => {
       };
       const reader = createReader(deps);
       await reader.init();
-      // voice should be set to fallback-voice (tested via cleanup/internal state)
-      // We verify indirectly: controls.selectedVoice was the fallback
       assert.equal(deps._mocks.mockControls.selectedVoice, "fallback-voice");
     });
   });
@@ -393,7 +391,6 @@ describe("createReader", () => {
       const reader = createReader(deps);
       await reader.init();
       deps._mocks.mockPort._fire({ type: "connected" });
-      // No error thrown — connected state is internal
     });
 
     it("handles ws-error by marking disconnected", async () => {
@@ -402,14 +399,12 @@ describe("createReader", () => {
       await reader.init();
       deps._mocks.mockPort._fire({ type: "connected" });
       deps._mocks.mockPort._fire({ type: "ws-error", conn: 0, message: "fail" });
-      // No crash — state is internal
     });
 
     it("ignores messages with invalid para IDs", async () => {
       const deps = makeDeps();
       const reader = createReader(deps);
       await reader.init();
-      // Should not throw
       deps._mocks.mockPort._fire({ type: "audio", id: "invalid", data: "abc" });
       deps._mocks.mockPort._fire({ type: "audio", id: null, data: "abc" });
       deps._mocks.mockPort._fire({ type: "audio", data: "abc" });
@@ -421,7 +416,6 @@ describe("createReader", () => {
       await reader.init();
       deps._mocks.mockPort._fire({ type: "audio", id: "para-0", data: "chunk1" });
       deps._mocks.mockPort._fire({ type: "audio", id: "para-0", data: "chunk2" });
-      // We verify indirectly via done event resolving pending
     });
 
     it("resolves pending request on done message", async () => {
@@ -437,14 +431,10 @@ describe("createReader", () => {
       await reader.init();
       deps._mocks.mockPort._fire({ type: "connected" });
 
-      // ensureBuffered dispatches and waits
       const ensurePromise = reader._ensureBuffered(0);
-
-      // Simulate TTS response
       deps._mocks.mockPort._fire({ type: "audio", id: "para-0", data: "audiodata" });
       deps._mocks.mockPort._fire({ type: "done", id: "para-0" });
 
-      // Should resolve without timeout
       await ensurePromise;
       assert.equal(mockScheduler.onFetchComplete.mock.callCount(), 1);
     });
@@ -454,7 +444,6 @@ describe("createReader", () => {
       const reader = createReader(deps);
       await reader.init();
       deps._mocks.mockPort._fireDisconnect();
-      // Internal state cleared — no crash on subsequent operations
     });
   });
 
@@ -488,7 +477,6 @@ describe("createReader", () => {
     it("is safe to call without init", () => {
       const deps = makeDeps();
       const reader = createReader(deps);
-      // Should not throw
       reader.cleanup();
     });
   });
@@ -501,7 +489,7 @@ describe("createReader", () => {
       deps._mocks.mockControls._cbs.onVoiceChange("ja-JP-NanamiNeural");
       assert.equal(deps.functions.saveVoicePref.mock.callCount(), 1);
       const args = deps.functions.saveVoicePref.mock.calls[0].arguments;
-      assert.equal(args[0], "en"); // currentLang
+      assert.equal(args[0], "en");
       assert.equal(args[1], "ja-JP-NanamiNeural");
       assert.equal(args[2], deps.browser.storage.local);
     });
@@ -514,7 +502,7 @@ describe("createReader", () => {
       await reader.init();
       deps._mocks.mockControls._cbs.onClose();
       assert.equal(deps._mocks.mockPlayer.destroy.mock.callCount(), 1);
-      const postCalls = deps.dom.window.parent.postMessage.mock.calls;
+      const postCalls = deps.env.window.parent.postMessage.mock.calls;
       assert.ok(postCalls.some((c) => c.arguments[0].type === "lactor-close"));
     });
   });
@@ -567,16 +555,13 @@ describe("createReader", () => {
       const deps = makeDeps();
       const reader = createReader(deps);
       await reader.init();
-      // Do NOT fire "connected" — bgConnected stays false, triggering retries
 
       const countBefore = deps._mocks.mockPort.postMessage.mock.callCount();
       reader._dispatchFetch({ conn: 0, index: 0, text: "Hello" });
       reader.cleanup();
 
-      // Wait long enough for several retries to have fired if not cancelled
       await new Promise((r) => setTimeout(r, 400));
 
-      // No new speak messages should have been sent after cleanup
       const speakCalls = deps._mocks.mockPort.postMessage.mock.calls
         .slice(countBefore)
         .filter((c) => c.arguments[0].action === "speak");
@@ -587,16 +572,13 @@ describe("createReader", () => {
       const deps = makeDeps();
       const reader = createReader(deps);
       await reader.init();
-      // bgConnected is false — dispatches will retry and trigger reconnect
 
       reader._dispatchFetch({ conn: 0, index: 0, text: "Hello" });
       reader._dispatchFetch({ conn: 1, index: 1, text: "World" });
 
-      // Count how many "connect" action messages were sent after init's own connect
       const connectCalls = deps._mocks.mockPort.postMessage.mock.calls.filter(
         (c) => c.arguments[0].action === "connect"
       );
-      // init sends one "connect"; retries should add at most one more (not two)
       assert.ok(
         connectCalls.length <= 2,
         `expected at most 2 connect calls (init + 1 reconnect), got ${connectCalls.length}`
@@ -609,15 +591,12 @@ describe("createReader", () => {
       const deps = makeDeps();
       const reader = createReader(deps);
       await reader.init();
-      // bgConnected is false
 
       reader._dispatchFetch({ conn: 0, index: 0, text: "Hello" });
 
-      // Simulate connection restored after a short delay
       await new Promise((r) => setTimeout(r, 150));
       deps._mocks.mockPort._fire({ type: "connected" });
 
-      // Wait for retry to pick it up
       await new Promise((r) => setTimeout(r, 200));
 
       const speakCalls = deps._mocks.mockPort.postMessage.mock.calls.filter(
@@ -635,11 +614,9 @@ describe("createReader", () => {
       const reader = createReader(deps);
       await reader.init();
 
-      // Pre-fill buffer via port messages
       deps._mocks.mockPort._fire({ type: "audio", id: "para-0", data: "chunk" });
       deps._mocks.mockPort._fire({ type: "done", id: "para-0" });
 
-      // Should resolve immediately
       await reader._ensureBuffered(0);
     });
 
@@ -668,10 +645,7 @@ describe("createReader", () => {
       await reader.init();
       deps._mocks.mockPort._fire({ type: "connected" });
 
-      // Start ensureBuffered without resolving it
       const promise = reader._ensureBuffered(0);
-
-      // Cleanup should reject the pending promise
       reader.cleanup();
 
       await assert.rejects(promise, { message: "cleanup" });
@@ -684,7 +658,6 @@ describe("createReader", () => {
       const reader = createReader(deps);
       await reader.init();
 
-      // Play past the last paragraph
       await reader._playFromParagraph(999);
       assert.equal(deps._mocks.mockControls.setPlaying.mock.callCount(), 1);
       assert.equal(deps._mocks.mockControls.setPlaying.mock.calls[0].arguments[0], false);
@@ -704,15 +677,10 @@ describe("createReader", () => {
       await reader.init();
       deps._mocks.mockPort._fire({ type: "connected" });
 
-      // Buffer para 0 with empty audio (done but no chunks)
       deps._mocks.mockPort._fire({ type: "done", id: "para-0" });
-
-      // Buffer para 1 with done but also empty — will chain through to end
       deps._mocks.mockPort._fire({ type: "done", id: "para-1" });
 
-      // Both paragraphs have no audio → should skip to end
       await reader._playFromParagraph(0);
-      // Eventually calls setPlaying(false) when it runs out of paragraphs
       assert.ok(deps._mocks.mockControls.setPlaying.mock.callCount() >= 1);
     });
 
@@ -730,7 +698,6 @@ describe("createReader", () => {
       await reader.init();
       deps._mocks.mockPort._fire({ type: "connected" });
 
-      // Buffer para 0 with audio data
       deps._mocks.mockPort._fire({ type: "audio", id: "para-0", data: "audio1" });
       deps._mocks.mockPort._fire({
         type: "word",
@@ -740,7 +707,6 @@ describe("createReader", () => {
         audioOffset: 0,
       });
       deps._mocks.mockPort._fire({ type: "done", id: "para-0" });
-      // Buffer para 1 as empty so the while-loop can terminate
       deps._mocks.mockPort._fire({ type: "done", id: "para-1" });
 
       await reader._playFromParagraph(0);
@@ -750,6 +716,64 @@ describe("createReader", () => {
       assert.equal(deps._mocks.mockHighlight.addWordEvents.mock.callCount(), 1);
       assert.equal(deps._mocks.mockPlayer.play.mock.callCount(), 1);
       assert.equal(deps._mocks.mockHighlight.start.mock.callCount(), 1);
+    });
+
+    it("calls ui.markCurrent and ui.markPlayed during playback", async () => {
+      const deps = makeDeps();
+      const mockScheduler = makeMockScheduler();
+      mockScheduler.fetchByIndex = mock.fn((i) => ({
+        conn: 0,
+        index: i,
+        text: "Hello world",
+      }));
+      deps.components.createScheduler = () => mockScheduler;
+
+      const reader = createReader(deps);
+      await reader.init();
+      deps._mocks.mockPort._fire({ type: "connected" });
+
+      deps._mocks.mockPort._fire({ type: "audio", id: "para-0", data: "audio1" });
+      deps._mocks.mockPort._fire({ type: "done", id: "para-0" });
+      deps._mocks.mockPort._fire({ type: "done", id: "para-1" });
+
+      await reader._playFromParagraph(0);
+
+      assert.ok(deps._mocks.mockUI.markCurrent.mock.callCount() >= 1);
+      assert.equal(deps._mocks.mockUI.markCurrent.mock.calls[0].arguments[0], 0);
+      assert.ok(deps._mocks.mockUI.markPlayed.mock.callCount() >= 1);
+      assert.equal(deps._mocks.mockUI.markPlayed.mock.calls[0].arguments[0], 0);
+    });
+
+    it("stops playback loop when decodeAudio throws", async () => {
+      const deps = makeDeps();
+      const mockScheduler = makeMockScheduler();
+      mockScheduler.fetchByIndex = mock.fn((i) => ({
+        conn: 0,
+        index: i,
+        text: "Hello world",
+      }));
+      deps.components.createScheduler = () => mockScheduler;
+      deps._mocks.mockPlayer.decodeAudio = mock.fn(async () => {
+        throw new Error("decode error");
+      });
+
+      const reader = createReader(deps);
+      await reader.init();
+      deps._mocks.mockPort._fire({ type: "connected" });
+
+      // Buffer para 0 with audio data that will fail to decode
+      deps._mocks.mockPort._fire({ type: "audio", id: "para-0", data: "bad-audio" });
+      deps._mocks.mockPort._fire({ type: "done", id: "para-0" });
+      // Buffer para 1 with audio data — should NOT be reached
+      deps._mocks.mockPort._fire({ type: "audio", id: "para-1", data: "audio1" });
+      deps._mocks.mockPort._fire({ type: "done", id: "para-1" });
+
+      await reader._playFromParagraph(0);
+
+      // decode was called for para 0 only, not para 1
+      assert.equal(deps._mocks.mockPlayer.decodeAudio.mock.callCount(), 1);
+      // play was never called (decode failed before play)
+      assert.equal(deps._mocks.mockPlayer.play.mock.callCount(), 0);
     });
   });
 });

--- a/extension/reader/reader.js
+++ b/extension/reader/reader.js
@@ -1,4 +1,5 @@
 import { createReader } from "./reader-core.js";
+import { createReaderUI } from "./components/reader-ui.js";
 import { HighlightEngine } from "./components/highlight.js";
 import { Player } from "./components/player.js";
 import { Controls } from "./components/controls.js";
@@ -15,11 +16,14 @@ import { loadVoicePrefs, saveVoicePref } from "./components/voice-prefs.js";
 import { loadConfig } from "../config.js";
 
 const reader = createReader({
-  dom: {
+  ui: createReaderUI({
     contentEl: document.getElementById("content"),
     loadingEl: document.getElementById("loading"),
     errorEl: document.getElementById("error"),
     document,
+    renderSegments,
+  }),
+  env: {
     window,
     location,
   },
@@ -39,7 +43,6 @@ const reader = createReader({
     createPipeline,
     sanitize,
     structure,
-    renderSegments,
     resolveVoice,
     loadCachedVoices,
     cacheVoices,

--- a/extension/reader/reader.js
+++ b/extension/reader/reader.js
@@ -3,6 +3,7 @@ import { HighlightEngine } from "./components/highlight.js";
 import { Player } from "./components/player.js";
 import { Controls } from "./components/controls.js";
 import { PrefetchScheduler } from "./components/scheduler.js";
+import { createPlaybackState } from "./components/playback-state.js";
 import { Logger, isDebugMode } from "./components/logger.js";
 import { createPipeline } from "./components/pipeline/index.js";
 import { sanitize } from "./components/pipeline/sanitize.js";
@@ -31,6 +32,7 @@ const reader = createReader({
     createHighlight: () => new HighlightEngine(),
     createControls: (cbs, opts) => new Controls(cbs, opts),
     createScheduler: (paras, cap) => new PrefetchScheduler(paras, cap),
+    createPlaybackState: (opts) => createPlaybackState(opts),
   },
   functions: {
     loadConfig,


### PR DESCRIPTION
## Summary

- 从 `reader-core.js` 提取独立的播放状态机模块 `playback-state.js`（5 状态 / 14 转换规则），统一管理 idle/loading/playing/paused/error 状态
- 提取 `reader-ui.js` 封装全部 DOM 操作（7 个方法），reader-core 不再直接引用任何 DOM API
- 拆分 `playFromParagraph`（~80 行）为 `playSingleSegment` + 纯循环驱动（~15 行）
- `deps.dom` 拆为 `deps.ui`（UI 接口）+ `deps.env`（window/location），测试从 JSDOM HTML 构造简化为 mock.fn()

Closes #15

## Test plan

- [ ] 295 个单元测试全部通过（`node --test extension/**/*.test.js`）
- [ ] ESLint 无错误（`npx eslint extension`）
- [ ] reader-core.js 中零 DOM 直接操作（`querySelector|classList|style.display|createElement` 零匹配）
- [ ] 状态机覆盖：所有合法转换、非法转换忽略+log、事件通知、goTo 段落导航、完整播放循环
- [ ] decode 失败回归测试：确认播放循环停止而非继续下一段